### PR TITLE
Moved solr-uri key to solr: uri outside of crawler-settings: key

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@
     
     
 
-    you can update solr-uri if you need
+    you can update solr.uri if you need
     
     ```
-    crawler-settings:
-      solr-uri: http://localhost:8983/solr/manufacturer_product
+    solr:
+        uri: http://localhost:8983/solr/manufacturer_product
     ```
  
     NOTE: if you get error for loading the application config in below steps, you may need to edit `applicationConfig` in `build.gradle` to absolute path

--- a/crawler-service/src/main/java/com/topcoder/productsearch/converter/service/SolrService.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/converter/service/SolrService.java
@@ -57,7 +57,7 @@ public class SolrService {
    *
    * @param serverURI the solr server uri
    */
-  public SolrService(@Value("${crawler-settings.solr-uri}") String serverURI) {
+  public SolrService(@Value("${solr.uri}") String serverURI) {
     httpSolrClient = new HttpSolrClient.Builder(serverURI).build();
     httpSolrClient.setParser(new XMLResponseParser());
   }

--- a/crawler-service/src/main/resources/application-default.yml
+++ b/crawler-service/src/main/resources/application-default.yml
@@ -46,6 +46,9 @@ cors:
   allowed-origins: "*"
   allowed-methods: HEAD,GET,PUT,POST,DELETE
 
+solr:
+  uri: http://127.0.0.1:8983/solr/manufacturer_product
+
 crawler-settings:
   #Interval between each subsequent request (milliseconds)
   interval: 1000
@@ -58,9 +61,6 @@ crawler-settings:
 
   #Max number of times to retry a single page.
   retry-times: 2
-
-  # the convert solr uri
-  solr-uri: http://127.0.0.1:8983/solr/manufacturer_product
 
   #Time lapse period for Expired pages in number of Days.
   page-expired-period: 30

--- a/crawler-service/src/main/resources/application-develop.yml
+++ b/crawler-service/src/main/resources/application-develop.yml
@@ -47,6 +47,10 @@ cors:
   allowed-origins: "*"
   allowed-methods: HEAD,GET,PUT,POST,DELETE
 
+# the convert solr uri
+solr:
+  uri: http://solr:8983/solr/manufacturer_product
+
 crawler-settings:
   #Interval between each subsequent request (milliseconds)
   interval: 1000
@@ -59,9 +63,6 @@ crawler-settings:
 
   #Max number of times to retry a single page.
   retry-times: 3
-
-  # the convert solr uri
-  solr-uri: http://solr:8983/solr/manufacturer_product
 
   #Time lapse period for Expired pages in number of Days.
   page-expired-period: 30


### PR DESCRIPTION
Moved solr-uri key to solr: uri outside of crawler-settings: key in application-*.yml file, Updated SolrService class to reference the new key in annotation.  Updated README.md for the solr key name change.