### PR TITLE
50 expired url delete attribute

### DIFF
--- a/crawler-service/src/main/java/com/topcoder/productsearch/cleaner/service/CleanerService.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/cleaner/service/CleanerService.java
@@ -89,7 +89,6 @@ public class CleanerService {
       logger.info("clean page for " + cPage.getUrl());
       try {
         solrService.deleteByURL(cPage.getUrl()); // remove from solr
-        }
       } catch (Exception e) {
         logger.error("delete from solr failed");
         e.printStackTrace();

--- a/crawler-service/src/main/java/com/topcoder/productsearch/cleaner/service/CleanerService.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/cleaner/service/CleanerService.java
@@ -75,7 +75,7 @@ public class CleanerService {
 
 
     /*
-     Expired pages will be deleted.  If the page has not been updated since a specified time,
+     Expired pages will be deleted from Solr.  If the page has not been updated since a specified time,
      Field last_modified_at in the pages table will be used to determine the time of last update.
      */
     Date expiresDate = java.sql.Date.valueOf(LocalDate.now().minusDays(pageExpiredPeriod));
@@ -89,9 +89,6 @@ public class CleanerService {
       logger.info("clean page for " + cPage.getUrl());
       try {
         solrService.deleteByURL(cPage.getUrl()); // remove from solr
-        if (!cPage.getDeleted()) {
-          cPage.setDeleted(true); // set deleted flag
-          pageRepository.save(cPage); // save cPage
         }
       } catch (Exception e) {
         logger.error("delete from solr failed");

--- a/crawler-service/src/test/java/com/topcoder/productsearch/cleaner/service/CleanerServiceTest.java
+++ b/crawler-service/src/test/java/com/topcoder/productsearch/cleaner/service/CleanerServiceTest.java
@@ -66,6 +66,12 @@ public class CleanerServiceTest extends AbstractUnitTest {
     cleanerService.setPageExpiredPeriod(10L);
     cPage.setLastModifiedAt(Date.from(Instant.now()));
     cleanerService.cleanPage(cPage);
+    verify(solrService, times(1)).deleteByURL(any(String.class));
+
+    cleanerService.setPageExpiredPeriod(10L);
+    cPage.setLastModifiedAt(Date.from(Instant.now()));
+    cPage.setDeleted(true);
+    cleanerService.cleanPage(cPage);
     verify(solrService, times(2)).deleteByURL(any(String.class));
 
     cleanerService.setSolrService(null);

--- a/crawler-service/src/test/java/com/topcoder/productsearch/cleaner/service/CleanerServiceTest.java
+++ b/crawler-service/src/test/java/com/topcoder/productsearch/cleaner/service/CleanerServiceTest.java
@@ -74,12 +74,6 @@ public class CleanerServiceTest extends AbstractUnitTest {
     cleanerService.cleanPage(cPage);
     verify(solrService, times(2)).deleteByURL(any(String.class));
 
-    cleanerService.setSolrService(null);
-    try {
-      cleanerService.cleanPage(cPage);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
 
   }
 }


### PR DESCRIPTION
Removed logic where expired pages were being marked as deleted .  This was happening when corresponding record in Solr was being deleted.  Also changed the test cases and cleaned up the test case by removing dead code.