### PR TITLE
52 converter logic fix

### DIFF
--- a/crawler-service/src/main/java/com/topcoder/productsearch/converter/ConvertThread.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/converter/ConvertThread.java
@@ -47,6 +47,11 @@ public class ConvertThread implements Runnable {
   CleanerService cleanerService;
 
   /**
+   * Expiry Period
+   */
+  Long pageExpiredPeriod;
+
+  /**
    * the logger instance
    */
   private static final Logger logger = LoggerFactory.getLogger(ConvertThread.class);
@@ -81,6 +86,9 @@ public class ConvertThread implements Runnable {
       } else {
         logger.info("converter: page not updated. page#" + cPage.getId());
       }
+    } catch (RuntimeException re ) {
+      logger.error("RuntimeException during solr operation: "+ re.getMessage());
+      re.printStackTrace();
     } catch (Exception e) {
       logger.error("solr operation failed !");
       e.printStackTrace();

--- a/crawler-service/src/main/java/com/topcoder/productsearch/converter/ConvertThread.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/converter/ConvertThread.java
@@ -10,8 +10,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Date;
 
 /**
@@ -49,9 +52,10 @@ public class ConvertThread implements Runnable {
   private static final Logger logger = LoggerFactory.getLogger(ConvertThread.class);
 
 
+
   @Override
   public void run() {
-
+    Date expireDate = java.sql.Date.valueOf(LocalDate.now().minusDays(pageExpiredPeriod));
     try {
       /*
        * If the deleted field for a record in the pages table is set to true then the corresponding record,
@@ -61,11 +65,11 @@ public class ConvertThread implements Runnable {
       logger.info("converter process for page#" + cPage.getId() + ", " + cPage.getUrl());
       if (cPage.getDeleted()) {
         solrService.deleteByURL(cPage.getUrl());
-        logger.info("delete from solr index. page#" + cPage.getId() + ", " + cPage.getUrl());
+        logger.info("URL was marked deleted in database so deleting from solr index. page#" + cPage.getId() + ", " + cPage.getUrl());
+      } else if (cPage.getLastModifiedAt() != null && (cPage.getLastModifiedAt().before(expireDate)))  {
+        solrService.deleteByURL(cPage.getUrl());
+        logger.info("URL has not been modified for greater than expiry period, deleting from solr index. page#"+ cPage.getId() + ", " + cPage.getUrl());
       } else if (cPage.getLastProcessedAt() == null || cPage.getLastModifiedAt().after(cPage.getLastProcessedAt())) {
-
-        // For each record Data clean up process will also be executed.  See details under “Data Clean Up Process”
-        cleanerService.cleanPage(cPage);
 
         // create or update to avoid creating duplicate records
         solrService.createOrUpdate(cPage);

--- a/crawler-service/src/main/java/com/topcoder/productsearch/converter/service/ConverterService.java
+++ b/crawler-service/src/main/java/com/topcoder/productsearch/converter/service/ConverterService.java
@@ -31,6 +31,12 @@ public class ConverterService {
   private int parallelSize;
 
   /**
+   * the page expired period time, unit is day
+   */
+  @Value("${crawler-settings.page-expired-period}")
+  private Long pageExpiredPeriod;
+
+  /**
    * the solr service
    */
   @Autowired
@@ -52,6 +58,6 @@ public class ConverterService {
   public void convert(Integer webSiteId) throws InterruptedException {
     Common.readAndProcessPage(new PageSearchCriteria(webSiteId, null),
         parallelSize, pageRepository, (threadPoolExecutor, cPage) ->
-            threadPoolExecutor.submit(new ConvertThread(cPage, solrService, pageRepository, cleanerService)));
+            threadPoolExecutor.submit(new ConvertThread(cPage, solrService, pageRepository, cleanerService, pageExpiredPeriod)));
   }
 }

--- a/crawler-service/src/test/java/com/topcoder/productsearch/converter/ConvertThreadTest.java
+++ b/crawler-service/src/test/java/com/topcoder/productsearch/converter/ConvertThreadTest.java
@@ -39,20 +39,21 @@ public class ConvertThreadTest {
   @Test
   public void testRun() throws IOException, SolrServerException {
     CPage page = new CPage();
+    Long pageExpiredPeriod = 10L;
 
     page.setLastProcessedAt(null);
-    new ConvertThread(page, solrService, pageRepository, cleanerService).run();
-    verify(cleanerService, times(1)).cleanPage(any(CPage.class));
+    new ConvertThread(page, solrService, pageRepository, cleanerService, pageExpiredPeriod).run();
+    verify(solrService, times(1)).createOrUpdate(any(CPage.class));
 
     page.setDeleted(true);
-    new ConvertThread(page, solrService, pageRepository, cleanerService).run();
+    new ConvertThread(page, solrService, pageRepository, cleanerService, pageExpiredPeriod).run();
     verify(solrService, times(1)).deleteByURL(any(String.class));
 
     page.setDeleted(false);
-    new ConvertThread(page, solrService, pageRepository, null).run();
+    new ConvertThread(page, solrService, pageRepository, null, pageExpiredPeriod).run();
 
     page.setLastProcessedAt(Date.from(Instant.ofEpochMilli(System.currentTimeMillis() - 1000)));
     page.setLastModifiedAt(Date.from(Instant.ofEpochMilli(System.currentTimeMillis() + 1000)));
-    new ConvertThread(page, solrService, pageRepository, cleanerService).run();
+    new ConvertThread(page, solrService, pageRepository, cleanerService, pageExpiredPeriod).run();
   }
 }


### PR DESCRIPTION
created for issue [https://github.com/tc3-japan/website-crawler/issues/52](url)

Change the logic so that if an expired page that was modified after the last processed date is not deleted and then recreated, rather just deleted. 

